### PR TITLE
Search loop logic

### DIFF
--- a/txtReplace.py
+++ b/txtReplace.py
@@ -26,7 +26,8 @@ for textfile in textfiles:
 		start = contents.find(findarg,start)
 		end = start+len(findarg)
 		contents = contents[:start]+replacearg+contents[end:]
-		start = end+1
+		start = start+len(replacearg)		#begin next pass right after what was added
+		
 	f.close()
 	g = open(textfile,'w')
 	g.write(contents)


### PR DESCRIPTION
Former search criteria would begin next search start point at a location
that could move if replacearg was a different length than findarg.  This
change now begins the search at the character immediately after the
newly inserted string.
